### PR TITLE
Update support for SAN

### DIFF
--- a/simple_ca/functions/create_server_cert.py
+++ b/simple_ca/functions/create_server_cert.py
@@ -49,6 +49,8 @@ class CreateServerCert:
 
     @staticmethod
     def _san_entry(name):
+        if name.startswith(('DNS:', 'IP:')):
+            return name
         try:
             ipaddress.ip_address(name)
             return 'IP:' + name

--- a/tests/test_simple_ca.py
+++ b/tests/test_simple_ca.py
@@ -40,7 +40,7 @@ def test_create_server_cert():
     assert len(sc.key_password) > 10
     
     
-def test_create_server_cert_with_san():
+def test_create_server_cert_with_san_dns():
     s = SimpleCA()
     ca = s.init_ca(org='ACME')
     # SimpleCA object is stateless, you have to pass CA data again to create server cert
@@ -55,7 +55,7 @@ def test_create_server_cert_with_san():
     assert 'DNS:localhost' in out
 
 
-def test_create_server_cert_with_san():
+def test_create_server_cert_with_san_hostname():
     s = SimpleCA()
     ca = s.init_ca(org='ACME')
     sc = s.create_server_cert(

--- a/tests/test_simple_ca.py
+++ b/tests/test_simple_ca.py
@@ -37,3 +37,13 @@ def test_create_server_cert():
     assert '-----BEGIN CERTIFICATE-----' in sc.cert
     assert '-----BEGIN RSA PRIVATE KEY-----' in sc.key
     assert len(sc.key_password) > 10
+    
+    
+def test_create_server_cert_with_san():
+    s = SimpleCA()
+    ca = s.init_ca(org='ACME')
+    # SimpleCA object is stateless, you have to pass CA data again to create server cert
+    sc = s.create_server_cert(
+        ca_cert=ca.cert, ca_key=ca.key, ca_key_password=ca.key_password,
+        cn='localhost', org='ACME', dc='example',
+        san=['DNS:localhost'])

--- a/tests/test_simple_ca.py
+++ b/tests/test_simple_ca.py
@@ -53,6 +53,8 @@ def test_create_server_cert_with_san_dns():
         ['openssl', 'x509', '-noout', '-text'],
         input=sc.cert.encode()).decode()
     assert 'DNS:localhost' in out
+    assert '    DNS:localhost\n' in out
+    assert 'DNS:DNS:localhost' not in out
 
 
 def test_create_server_cert_with_san_hostname():
@@ -69,4 +71,4 @@ def test_create_server_cert_with_san_hostname():
         input=sc.cert.encode()).decode()
     assert 'DNS:example.com' in out
     assert 'DNS:*.example.com' in out
-    assert '    DNS:example.com, DNS:*.example.com' in out
+    assert '    DNS:example.com, DNS:*.example.com\n' in out


### PR DESCRIPTION
SAN = subjectAltName

For example MongoDB shell prints a warning when the mongod server certificate doesn't contain SAN.