### PR TITLE
Add intermediate CA support with certificate chain building

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,19 +34,19 @@ make lint-fix
 
 ### Public API
 
-- **`RootCA`** class (in `simple_ca/ca.py`) — root Certificate Authority. Inherits from `CKP` namedtuple via `_CABase`.
+- **`RootCA`** class (in `simple_ca/ca.py`) — root Certificate Authority. Inherits from `_CABase`.
   - `RootCA.init_ca(org, cn='CA', *, days=DEFAULT_VALIDITY_DAYS)` — class method, creates a new root CA
   - `RootCA(cert, key, key_password)` — construct from existing PEM data
   - `root.create_intermediate_ca(org, cn='Intermediate CA', *, days=DEFAULT_VALIDITY_DAYS)` — creates an `IntermediateCA` signed by this CA
-  - `root.create_server_cert(cn, org, dc=None, san=None, *, days=DEFAULT_VALIDITY_DAYS)` — creates a server certificate, returns `CKP`
-- **`IntermediateCA`** class (in `simple_ca/ca.py`) — intermediate Certificate Authority. Inherits from `CKP` namedtuple via `_CABase`.
+  - `root.create_server_cert(cn, org, dc=None, san=None, *, days=DEFAULT_VALIDITY_DAYS)` — creates a server certificate, returns `CertKeyPair`
+- **`IntermediateCA`** class (in `simple_ca/ca.py`) — intermediate Certificate Authority. Inherits from `_CABase`.
   - `IntermediateCA(cert, key, key_password, *, parent=ca_obj)` — construct from existing PEM data with parent CA object
   - `IntermediateCA(cert, key, key_password, *, parent_ca_cert=pem_str)` — construct from existing PEM data with parent cert PEM
   - `inter.create_server_cert(...)` — same as RootCA
   - `inter.create_intermediate_ca(...)` — same as RootCA
 - **`CA`** — backward-compatible alias for `RootCA`
 - **`SimpleCA`** class (in `simple_ca/simple_ca.py`) — legacy API, delegates to `CA`
-- **`CKP`** namedtuple (in `simple_ca/types.py`) — holds `cert`, `key`, `key_password`, `cert_chain`, and `serial` (all strings, PEM-encoded; `cert_chain` and `serial` default to `None`)
+- **`CertKeyPair`** dataclass (in `simple_ca/types.py`) — holds `cert`, `key`, `key_password`, `cert_chain`, and `serial` (all strings, PEM-encoded; `cert_chain` and `serial` default to `None`)
 - **`DEFAULT_VALIDITY_DAYS`** constant (in `simple_ca/types.py`) — default certificate validity period (10000 days)
 
 All are exported from `simple_ca/__init__.py`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,13 +35,14 @@ make lint-fix
 ### Public API
 
 - **`CA`** class (in `simple_ca/ca.py`) — the recommended API. Inherits from `CKP` namedtuple.
-  - `CA.init_ca(org, cn)` — class method, creates a new root CA and returns a `CA` instance
-  - `ca.create_intermediate_ca(org, cn)` — creates an intermediate CA signed by this CA, returns a new `CA` instance
-  - `ca.create_server_cert(cn, org, dc, san)` — creates a server certificate signed by this CA, returns `CKP`
+  - `CA.init_ca(org, cn='CA', *, days=DEFAULT_VALIDITY_DAYS)` — class method, creates a new root CA and returns a `CA` instance
+  - `ca.create_intermediate_ca(org, cn='Intermediate CA', *, days=DEFAULT_VALIDITY_DAYS)` — creates an intermediate CA signed by this CA, returns a new `CA` instance
+  - `ca.create_server_cert(cn, org, dc=None, san=None, *, days=DEFAULT_VALIDITY_DAYS)` — creates a server certificate signed by this CA, returns `CKP`
 - **`SimpleCA`** class (in `simple_ca/simple_ca.py`) — legacy API, delegates to `CA`
-- **`CKP`** namedtuple (in `simple_ca/types.py`) — holds `cert`, `key`, `key_password`, and `cert_chain` (all strings, PEM-encoded; `cert_chain` is optional and contains the full certificate chain for TLS)
+- **`CKP`** namedtuple (in `simple_ca/types.py`) — holds `cert`, `key`, `key_password`, `cert_chain`, and `serial` (all strings, PEM-encoded; `cert_chain` and `serial` default to `None`)
+- **`DEFAULT_VALIDITY_DAYS`** constant (in `simple_ca/types.py`) — default certificate validity period (10000 days)
 
-All three are exported from `simple_ca/__init__.py`.
+All four are exported from `simple_ca/__init__.py`.
 
 ### Internal structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,15 +34,22 @@ make lint-fix
 
 ### Public API
 
-- **`CA`** class (in `simple_ca/ca.py`) — the recommended API. Inherits from `CKP` namedtuple.
-  - `CA.init_ca(org, cn='CA', *, days=DEFAULT_VALIDITY_DAYS)` — class method, creates a new root CA and returns a `CA` instance
-  - `ca.create_intermediate_ca(org, cn='Intermediate CA', *, days=DEFAULT_VALIDITY_DAYS)` — creates an intermediate CA signed by this CA, returns a new `CA` instance
-  - `ca.create_server_cert(cn, org, dc=None, san=None, *, days=DEFAULT_VALIDITY_DAYS)` — creates a server certificate signed by this CA, returns `CKP`
+- **`RootCA`** class (in `simple_ca/ca.py`) — root Certificate Authority. Inherits from `CKP` namedtuple via `_CABase`.
+  - `RootCA.init_ca(org, cn='CA', *, days=DEFAULT_VALIDITY_DAYS)` — class method, creates a new root CA
+  - `RootCA(cert, key, key_password)` — construct from existing PEM data
+  - `root.create_intermediate_ca(org, cn='Intermediate CA', *, days=DEFAULT_VALIDITY_DAYS)` — creates an `IntermediateCA` signed by this CA
+  - `root.create_server_cert(cn, org, dc=None, san=None, *, days=DEFAULT_VALIDITY_DAYS)` — creates a server certificate, returns `CKP`
+- **`IntermediateCA`** class (in `simple_ca/ca.py`) — intermediate Certificate Authority. Inherits from `CKP` namedtuple via `_CABase`.
+  - `IntermediateCA(cert, key, key_password, *, parent=ca_obj)` — construct from existing PEM data with parent CA object
+  - `IntermediateCA(cert, key, key_password, *, parent_ca_cert=pem_str)` — construct from existing PEM data with parent cert PEM
+  - `inter.create_server_cert(...)` — same as RootCA
+  - `inter.create_intermediate_ca(...)` — same as RootCA
+- **`CA`** — backward-compatible alias for `RootCA`
 - **`SimpleCA`** class (in `simple_ca/simple_ca.py`) — legacy API, delegates to `CA`
 - **`CKP`** namedtuple (in `simple_ca/types.py`) — holds `cert`, `key`, `key_password`, `cert_chain`, and `serial` (all strings, PEM-encoded; `cert_chain` and `serial` default to `None`)
 - **`DEFAULT_VALIDITY_DAYS`** constant (in `simple_ca/types.py`) — default certificate validity period (10000 days)
 
-All four are exported from `simple_ca/__init__.py`.
+All are exported from `simple_ca/__init__.py`.
 
 ### Internal structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,11 @@ make lint-fix
 ### Public API
 
 - **`CA`** class (in `simple_ca/ca.py`) — the recommended API. Inherits from `CKP` namedtuple.
-  - `CA.init_ca(org, cn)` — class method, creates a new CA and returns a `CA` instance
+  - `CA.init_ca(org, cn)` — class method, creates a new root CA and returns a `CA` instance
+  - `ca.create_intermediate_ca(org, cn)` — creates an intermediate CA signed by this CA, returns a new `CA` instance
   - `ca.create_server_cert(cn, org, dc, san)` — creates a server certificate signed by this CA, returns `CKP`
 - **`SimpleCA`** class (in `simple_ca/simple_ca.py`) — legacy API, delegates to `CA`
-- **`CKP`** namedtuple (in `simple_ca/types.py`) — holds `cert`, `key`, and `key_password` (all strings, PEM-encoded)
+- **`CKP`** namedtuple (in `simple_ca/types.py`) — holds `cert`, `key`, `key_password`, and `cert_chain` (all strings, PEM-encoded; `cert_chain` is optional and contains the full certificate chain for TLS)
 
 All three are exported from `simple_ca/__init__.py`.
 
@@ -46,6 +47,7 @@ All three are exported from `simple_ca/__init__.py`.
 
 - `simple_ca/openssl_cli.py` — `OpenSSLCLI` class: thin wrapper that calls the `openssl` binary via subprocess
 - `simple_ca/functions/init_ca.py` — `InitCA`: creates CA key+cert using temp directory with openssl config files
+- `simple_ca/functions/create_intermediate_ca.py` — `CreateIntermediateCA`: creates intermediate CA key, CSR, and cert signed by parent CA (with `CA:true, pathlen:0` extensions)
 - `simple_ca/functions/create_server_cert.py` — `CreateServerCert`: creates server key, CSR, and cert signed by CA; supports SAN (Subject Alternative Names) for DNS names and IP addresses
 
 Each function class works by writing openssl config files and key material to a `TemporaryDirectory`, invoking openssl commands, then reading back the results. The temp directory is cleaned up automatically.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 uv=uv
 
 check:
-	$(uv) run pytest -vv $(pytest_args) tests
+	$(uv) run pytest -vv -n 6 $(pytest_args) tests
 
 lint:
 	$(uv) run ruff check .

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ sc = ca.create_server_cert(cn='localhost', org='ACME', dc='example')
 # sc.cert is the SSL certficate
 # sc.key is key to that certificate (needed on the server)
 # sc.key_password is password to the key, keep this private
+# sc.serial is the certificate serial number (hex string)
 ```
 
 You can also reconstruct a `CA` object from previously saved PEM data:
@@ -81,7 +82,12 @@ In this scenario, traditional certificate revocation mechanisms (CRL, OCSP) are 
 
 This approach avoids the complexity of running CRL distribution points or OCSP responders, and eliminates the window of vulnerability inherent in periodic CRL refresh. It works well when certificate deployment is already automated as part of your infrastructure provisioning.
 
-For additional defense in depth, consider using **short-lived certificates** (hours to days) with automated renewal, so that even without explicit revocation, a compromised certificate becomes useless quickly.
+For additional defense in depth, consider using **short-lived certificates** (hours to days) with automated renewal, so that even without explicit revocation, a compromised certificate becomes useless quickly. You can control certificate validity via the `days` parameter:
+
+```python
+ca = CA.init_ca(org='ACME', days=3650)  # CA valid for 10 years
+sc = ca.create_server_cert(cn='localhost', org='ACME', days=30)  # cert valid for 30 days
+```
 
 
 Similar projects

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Simple CA
 =========
 
-__Python OpenSSL wrapper__ that can create __your own certificate authority (CA)__ and create server certficates with it.
+__Python OpenSSL wrapper__ you can use to create __your own certificate authority (CA)__ and create server certificates with it.
 
 Use cases:
 
@@ -46,6 +46,20 @@ sc = ca.create_server_cert(cn='localhost', org='ACME')
 I recommend to store the `cert` and `key` in plain text files and `key_password` in encrypted file (using GPG, [AGE](https://age-encryption.org) etc.).
 
 
+### Intermediate CA
+
+You can create an intermediate CA for additional security — the root CA key can be kept offline:
+
+```python
+root_ca = CA.init_ca(org='ACME', cn='Root CA')
+intermediate_ca = root_ca.create_intermediate_ca(org='ACME', cn='Intermediate CA')
+
+sc = intermediate_ca.create_server_cert(cn='localhost', org='ACME', san=['localhost'])
+# sc.cert_chain contains the full certificate chain (server cert + intermediate cert)
+# Use sc.cert_chain (not sc.cert) when configuring TLS servers
+```
+
+
 ### Legacy API
 
 ```python
@@ -56,6 +70,18 @@ sc = s.create_server_cert(
     ca_cert=ca.cert, ca_key=ca.key, ca_key_password=ca.key_password,
     cn='localhost', org='ACME', dc='example')
 ```
+
+
+Certificate invalidation
+------------------------
+
+This project is designed primarily for **internal infrastructures** — database clusters (MongoDB, PostgreSQL, CockroachDB…) using TLS for inter-node and client-server communication, internal microservices, VPNs, and similar setups where all clients and servers are under your control via configuration management (Ansible, Puppet, Kubernetes operators, etc.).
+
+In this scenario, traditional certificate revocation mechanisms (CRL, OCSP) are usually unnecessary. Since you control all endpoints, the simplest and most reliable invalidation strategy is **full regeneration and redeployment**.
+
+This approach avoids the complexity of running CRL distribution points or OCSP responders, and eliminates the window of vulnerability inherent in periodic CRL refresh. It works well when certificate deployment is already automated as part of your infrastructure provisioning.
+
+For additional defense in depth, consider using **short-lived certificates** (hours to days) with automated renewal, so that even without explicit revocation, a compromised certificate becomes useless quickly.
 
 
 Similar projects

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Usage
 -----
 
 ```python
-from simple_ca import CA
+from simple_ca import CA  # CA is an alias for RootCA
 
 ca = CA.init_ca(org='ACME')
 # now you have created your own CA
@@ -58,6 +58,22 @@ intermediate_ca = root_ca.create_intermediate_ca(org='ACME', cn='Intermediate CA
 sc = intermediate_ca.create_server_cert(cn='localhost', org='ACME', san=['localhost'])
 # sc.cert_chain contains the full certificate chain (server cert + intermediate cert)
 # Use sc.cert_chain (not sc.cert) when configuring TLS servers
+```
+
+You can reconstruct an `IntermediateCA` from previously saved PEM data:
+
+```python
+from simple_ca import RootCA, IntermediateCA
+
+root = RootCA(cert=root_cert, key=root_key, key_password=root_key_password)
+inter = IntermediateCA(cert=inter_cert, key=inter_key, key_password=inter_key_password, parent=root)
+sc = inter.create_server_cert(cn='localhost', org='ACME', san=['localhost'])
+```
+
+If you don't have the root CA as an object, you can pass the root certificate PEM directly:
+
+```python
+inter = IntermediateCA(cert=inter_cert, key=inter_key, key_password=inter_key_password, parent_ca_cert=root_cert_pem)
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ requires-python = ">=3.9"
 dev = [
     "pytest",
     "pytest-asyncio>=1.2.0",
+    "pytest-xdist>=3.8.0",
     "ruff",
 ]
 

--- a/simple_ca/__init__.py
+++ b/simple_ca/__init__.py
@@ -1,6 +1,6 @@
 from .simple_ca import SimpleCA
 from .ca import CA
-from .types import CKP
+from .types import CKP, DEFAULT_VALIDITY_DAYS
 
 
 __version__ = '0.0.2'
@@ -8,5 +8,6 @@ __version__ = '0.0.2'
 __all__ = [
     'CA',
     'CKP',
+    'DEFAULT_VALIDITY_DAYS',
     'SimpleCA',
 ]

--- a/simple_ca/__init__.py
+++ b/simple_ca/__init__.py
@@ -1,5 +1,5 @@
 from .simple_ca import SimpleCA
-from .ca import CA
+from .ca import CA, RootCA, IntermediateCA
 from .types import CKP, DEFAULT_VALIDITY_DAYS
 
 
@@ -9,5 +9,7 @@ __all__ = [
     'CA',
     'CKP',
     'DEFAULT_VALIDITY_DAYS',
+    'IntermediateCA',
+    'RootCA',
     'SimpleCA',
 ]

--- a/simple_ca/__init__.py
+++ b/simple_ca/__init__.py
@@ -1,13 +1,13 @@
 from .simple_ca import SimpleCA
 from .ca import CA, RootCA, IntermediateCA
-from .types import CKP, DEFAULT_VALIDITY_DAYS
+from .types import CertKeyPair, DEFAULT_VALIDITY_DAYS
 
 
 __version__ = '0.0.2'
 
 __all__ = [
     'CA',
-    'CKP',
+    'CertKeyPair',
     'DEFAULT_VALIDITY_DAYS',
     'IntermediateCA',
     'RootCA',

--- a/simple_ca/ca.py
+++ b/simple_ca/ca.py
@@ -1,4 +1,4 @@
-from .types import CKP
+from .types import CKP, DEFAULT_VALIDITY_DAYS
 from .openssl_cli import OpenSSLCLI
 from .functions.init_ca import InitCA
 from .functions.create_intermediate_ca import CreateIntermediateCA
@@ -16,7 +16,18 @@ class CA(CKP):
     or construct directly from existing PEM data.
     """
 
-    def __new__(cls, cert, key, key_password, cert_chain=None, *, _openssl_cli=None, _chain_pem='', _verify_chain=None):
+    def __new__(
+        cls,
+        cert,
+        key,
+        key_password,
+        cert_chain=None,
+        serial=None,
+        *,
+        _openssl_cli=None,
+        _chain_pem='',
+        _verify_chain=None,
+    ):
         """
         Construct a CA from existing PEM data.
 
@@ -24,10 +35,11 @@ class CA(CKP):
         :param key: CA private key (PEM-encoded string)
         :param key_password: password to the CA private key
         :param cert_chain: full certificate chain (PEM-encoded string, optional)
+        :param serial: certificate serial number (hex string, optional)
         """
         # Using __new__ instead of __init__ because namedtuple
         # instances are created in __new__, not __init__.
-        obj = super().__new__(cls, cert=cert, key=key, key_password=key_password, cert_chain=cert_chain)
+        obj = super().__new__(cls, cert=cert, key=key, key_password=key_password, cert_chain=cert_chain, serial=serial)
         obj._openssl_cli = _openssl_cli or OpenSSLCLI()
         # _chain_pem: intermediate certs to append when building cert_chain for leaf certs.
         # Empty string for root CA, intermediate cert(s) PEM for intermediate CAs.
@@ -37,32 +49,35 @@ class CA(CKP):
         return obj
 
     @classmethod
-    def init_ca(cls, org, cn='CA', *, _openssl_cli=None):
+    def init_ca(cls, org, cn='CA', *, days=DEFAULT_VALIDITY_DAYS, _openssl_cli=None):
         """
         Create a new Certificate Authority.
 
         :param org: Organization Name
         :param cn: Common Name (default: 'CA')
+        :param days: certificate validity in days (default: DEFAULT_VALIDITY_DAYS)
         :return: CA instance with generated cert, key and key_password
         """
         openssl_cli = _openssl_cli or OpenSSLCLI()
         x = InitCA(openssl_cli)
-        x.run(org=org, cn=cn)
+        x.run(org=org, cn=cn, days=days)
         return cls(
             cert=x.cert,
             key=x.key,
             key_password=x.key_password,
+            serial=x.serial,
             _openssl_cli=openssl_cli,
             _chain_pem='',
             _verify_chain=x.cert,
         )
 
-    def create_intermediate_ca(self, org, cn='Intermediate CA'):
+    def create_intermediate_ca(self, org, cn='Intermediate CA', *, days=DEFAULT_VALIDITY_DAYS):
         """
         Create an intermediate CA signed by this CA.
 
         :param org: Organization Name
         :param cn: Common Name (default: 'Intermediate CA')
+        :param days: certificate validity in days (default: DEFAULT_VALIDITY_DAYS)
         :return: CA instance for the intermediate CA
         """
         x = CreateIntermediateCA(
@@ -72,7 +87,7 @@ class CA(CKP):
             ca_key_password=self.key_password,
             ca_verify_chain=self._verify_chain,
         )
-        x.run(org=org, cn=cn)
+        x.run(org=org, cn=cn, days=days)
         chain_pem = x.cert + self._chain_pem
         verify_chain = x.cert + self._verify_chain
         return CA(
@@ -80,12 +95,13 @@ class CA(CKP):
             key=x.key,
             key_password=x.key_password,
             cert_chain=chain_pem,
+            serial=x.serial,
             _openssl_cli=self._openssl_cli,
             _chain_pem=chain_pem,
             _verify_chain=verify_chain,
         )
 
-    def create_server_cert(self, cn, org, dc=None, san=None):
+    def create_server_cert(self, cn, org, dc=None, san=None, *, days=DEFAULT_VALIDITY_DAYS):
         """
         Create a server certificate signed by this CA.
 
@@ -93,7 +109,8 @@ class CA(CKP):
         :param org: Organization Name
         :param dc: Domain Component (optional)
         :param san: list of Subject Alternative Names, e.g. ['DNS:localhost', '10.0.0.1'] (optional)
-        :return: CKP namedtuple with cert, key, key_password and cert_chain
+        :param days: certificate validity in days (default: DEFAULT_VALIDITY_DAYS)
+        :return: CKP namedtuple with cert, key, key_password, cert_chain and serial
         """
         x = CreateServerCert(
             self._openssl_cli,
@@ -102,6 +119,6 @@ class CA(CKP):
             ca_key_password=self.key_password,
             ca_verify_chain=self._verify_chain,
         )
-        x.run(cn=cn, org=org, dc=dc, san=san)
+        x.run(cn=cn, org=org, dc=dc, san=san, days=days)
         cert_chain = x.cert + self._chain_pem
-        return CKP(cert=x.cert, key=x.key, key_password=x.key_password, cert_chain=cert_chain)
+        return CKP(cert=x.cert, key=x.key, key_password=x.key_password, cert_chain=cert_chain, serial=x.serial)

--- a/simple_ca/ca.py
+++ b/simple_ca/ca.py
@@ -1,6 +1,7 @@
 from .types import CKP
 from .openssl_cli import OpenSSLCLI
 from .functions.init_ca import InitCA
+from .functions.create_intermediate_ca import CreateIntermediateCA
 from .functions.create_server_cert import CreateServerCert
 
 
@@ -15,18 +16,24 @@ class CA(CKP):
     or construct directly from existing PEM data.
     """
 
-    def __new__(cls, cert, key, key_password, *, _openssl_cli=None):
+    def __new__(cls, cert, key, key_password, cert_chain=None, *, _openssl_cli=None, _chain_pem='', _verify_chain=None):
         """
         Construct a CA from existing PEM data.
 
         :param cert: CA certificate (PEM-encoded string)
         :param key: CA private key (PEM-encoded string)
         :param key_password: password to the CA private key
+        :param cert_chain: full certificate chain (PEM-encoded string, optional)
         """
         # Using __new__ instead of __init__ because namedtuple
         # instances are created in __new__, not __init__.
-        obj = super().__new__(cls, cert=cert, key=key, key_password=key_password)
+        obj = super().__new__(cls, cert=cert, key=key, key_password=key_password, cert_chain=cert_chain)
         obj._openssl_cli = _openssl_cli or OpenSSLCLI()
+        # _chain_pem: intermediate certs to append when building cert_chain for leaf certs.
+        # Empty string for root CA, intermediate cert(s) PEM for intermediate CAs.
+        obj._chain_pem = _chain_pem
+        # _verify_chain: full CA bundle (all CA certs from this CA up to root) for openssl verify.
+        obj._verify_chain = _verify_chain if _verify_chain is not None else cert
         return obj
 
     @classmethod
@@ -41,7 +48,42 @@ class CA(CKP):
         openssl_cli = _openssl_cli or OpenSSLCLI()
         x = InitCA(openssl_cli)
         x.run(org=org, cn=cn)
-        return cls(cert=x.cert, key=x.key, key_password=x.key_password, _openssl_cli=openssl_cli)
+        return cls(
+            cert=x.cert,
+            key=x.key,
+            key_password=x.key_password,
+            _openssl_cli=openssl_cli,
+            _chain_pem='',
+            _verify_chain=x.cert,
+        )
+
+    def create_intermediate_ca(self, org, cn='Intermediate CA'):
+        """
+        Create an intermediate CA signed by this CA.
+
+        :param org: Organization Name
+        :param cn: Common Name (default: 'Intermediate CA')
+        :return: CA instance for the intermediate CA
+        """
+        x = CreateIntermediateCA(
+            self._openssl_cli,
+            ca_cert=self.cert,
+            ca_key=self.key,
+            ca_key_password=self.key_password,
+            ca_verify_chain=self._verify_chain,
+        )
+        x.run(org=org, cn=cn)
+        chain_pem = x.cert + self._chain_pem
+        verify_chain = x.cert + self._verify_chain
+        return CA(
+            cert=x.cert,
+            key=x.key,
+            key_password=x.key_password,
+            cert_chain=chain_pem,
+            _openssl_cli=self._openssl_cli,
+            _chain_pem=chain_pem,
+            _verify_chain=verify_chain,
+        )
 
     def create_server_cert(self, cn, org, dc=None, san=None):
         """
@@ -51,8 +93,15 @@ class CA(CKP):
         :param org: Organization Name
         :param dc: Domain Component (optional)
         :param san: list of Subject Alternative Names, e.g. ['DNS:localhost', '10.0.0.1'] (optional)
-        :return: CKP namedtuple with cert, key and key_password
+        :return: CKP namedtuple with cert, key, key_password and cert_chain
         """
-        x = CreateServerCert(self._openssl_cli, ca_cert=self.cert, ca_key=self.key, ca_key_password=self.key_password)
+        x = CreateServerCert(
+            self._openssl_cli,
+            ca_cert=self.cert,
+            ca_key=self.key,
+            ca_key_password=self.key_password,
+            ca_verify_chain=self._verify_chain,
+        )
         x.run(cn=cn, org=org, dc=dc, san=san)
-        return CKP(cert=x.cert, key=x.key, key_password=x.key_password)
+        cert_chain = x.cert + self._chain_pem
+        return CKP(cert=x.cert, key=x.key, key_password=x.key_password, cert_chain=cert_chain)

--- a/simple_ca/ca.py
+++ b/simple_ca/ca.py
@@ -5,71 +5,13 @@ from .functions.create_intermediate_ca import CreateIntermediateCA
 from .functions.create_server_cert import CreateServerCert
 
 
-class CA(CKP):
+class _CABase(CKP):
     """
-    Certificate Authority with cert, key and key_password.
+    Base class for Certificate Authorities.
 
-    Inherits from CKP namedtuple, so it supports attribute access,
-    tuple unpacking and indexing.
-
-    Create a new CA using the class method :meth:`init_ca`,
-    or construct directly from existing PEM data.
+    Provides shared functionality for creating intermediate CAs
+    and server certificates. Not intended to be instantiated directly.
     """
-
-    def __new__(
-        cls,
-        cert,
-        key,
-        key_password,
-        cert_chain=None,
-        serial=None,
-        *,
-        _openssl_cli=None,
-        _chain_pem='',
-        _verify_chain=None,
-    ):
-        """
-        Construct a CA from existing PEM data.
-
-        :param cert: CA certificate (PEM-encoded string)
-        :param key: CA private key (PEM-encoded string)
-        :param key_password: password to the CA private key
-        :param cert_chain: full certificate chain (PEM-encoded string, optional)
-        :param serial: certificate serial number (hex string, optional)
-        """
-        # Using __new__ instead of __init__ because namedtuple
-        # instances are created in __new__, not __init__.
-        obj = super().__new__(cls, cert=cert, key=key, key_password=key_password, cert_chain=cert_chain, serial=serial)
-        obj._openssl_cli = _openssl_cli or OpenSSLCLI()
-        # _chain_pem: intermediate certs to append when building cert_chain for leaf certs.
-        # Empty string for root CA, intermediate cert(s) PEM for intermediate CAs.
-        obj._chain_pem = _chain_pem
-        # _verify_chain: full CA bundle (all CA certs from this CA up to root) for openssl verify.
-        obj._verify_chain = _verify_chain if _verify_chain is not None else cert
-        return obj
-
-    @classmethod
-    def init_ca(cls, org, cn='CA', *, days=DEFAULT_VALIDITY_DAYS, _openssl_cli=None):
-        """
-        Create a new Certificate Authority.
-
-        :param org: Organization Name
-        :param cn: Common Name (default: 'CA')
-        :param days: certificate validity in days (default: DEFAULT_VALIDITY_DAYS)
-        :return: CA instance with generated cert, key and key_password
-        """
-        openssl_cli = _openssl_cli or OpenSSLCLI()
-        x = InitCA(openssl_cli)
-        x.run(org=org, cn=cn, days=days)
-        return cls(
-            cert=x.cert,
-            key=x.key,
-            key_password=x.key_password,
-            serial=x.serial,
-            _openssl_cli=openssl_cli,
-            _chain_pem='',
-            _verify_chain=x.cert,
-        )
 
     def create_intermediate_ca(self, org, cn='Intermediate CA', *, days=DEFAULT_VALIDITY_DAYS):
         """
@@ -78,7 +20,7 @@ class CA(CKP):
         :param org: Organization Name
         :param cn: Common Name (default: 'Intermediate CA')
         :param days: certificate validity in days (default: DEFAULT_VALIDITY_DAYS)
-        :return: CA instance for the intermediate CA
+        :return: IntermediateCA instance
         """
         x = CreateIntermediateCA(
             self._openssl_cli,
@@ -90,7 +32,7 @@ class CA(CKP):
         x.run(org=org, cn=cn, days=days)
         chain_pem = x.cert + self._chain_pem
         verify_chain = x.cert + self._verify_chain
-        return CA(
+        return IntermediateCA(
             cert=x.cert,
             key=x.key,
             key_password=x.key_password,
@@ -122,3 +64,138 @@ class CA(CKP):
         x.run(cn=cn, org=org, dc=dc, san=san, days=days)
         cert_chain = x.cert + self._chain_pem
         return CKP(cert=x.cert, key=x.key, key_password=x.key_password, cert_chain=cert_chain, serial=x.serial)
+
+
+class RootCA(_CABase):
+    """
+    Root Certificate Authority.
+
+    Inherits from CKP namedtuple, so it supports attribute access,
+    tuple unpacking and indexing.
+
+    Create a new root CA using the class method :meth:`init_ca`,
+    or construct directly from existing PEM data.
+    """
+
+    def __new__(
+        cls,
+        cert,
+        key,
+        key_password,
+        cert_chain=None,
+        serial=None,
+        *,
+        _openssl_cli=None,
+        _chain_pem='',
+        _verify_chain=None,
+    ):
+        """
+        Construct a root CA from existing PEM data.
+
+        :param cert: CA certificate (PEM-encoded string)
+        :param key: CA private key (PEM-encoded string)
+        :param key_password: password to the CA private key
+        :param cert_chain: full certificate chain (PEM-encoded string, optional)
+        :param serial: certificate serial number (hex string, optional)
+        """
+        # Using __new__ instead of __init__ because namedtuple
+        # instances are created in __new__, not __init__.
+        obj = super().__new__(cls, cert=cert, key=key, key_password=key_password, cert_chain=cert_chain, serial=serial)
+        obj._openssl_cli = _openssl_cli or OpenSSLCLI()
+        obj._chain_pem = _chain_pem
+        obj._verify_chain = _verify_chain if _verify_chain is not None else cert
+        return obj
+
+    @classmethod
+    def init_ca(cls, org, cn='CA', *, days=DEFAULT_VALIDITY_DAYS, _openssl_cli=None):
+        """
+        Create a new Certificate Authority.
+
+        :param org: Organization Name
+        :param cn: Common Name (default: 'CA')
+        :param days: certificate validity in days (default: DEFAULT_VALIDITY_DAYS)
+        :return: RootCA instance with generated cert, key and key_password
+        """
+        openssl_cli = _openssl_cli or OpenSSLCLI()
+        x = InitCA(openssl_cli)
+        x.run(org=org, cn=cn, days=days)
+        return cls(
+            cert=x.cert,
+            key=x.key,
+            key_password=x.key_password,
+            serial=x.serial,
+            _openssl_cli=openssl_cli,
+            _chain_pem='',
+            _verify_chain=x.cert,
+        )
+
+
+class IntermediateCA(_CABase):
+    """
+    Intermediate Certificate Authority.
+
+    Inherits from CKP namedtuple, so it supports attribute access,
+    tuple unpacking and indexing.
+
+    Create a new intermediate CA using :meth:`RootCA.create_intermediate_ca`
+    (or :meth:`IntermediateCA.create_intermediate_ca`),
+    or construct directly from existing PEM data by providing
+    either a ``parent`` CA object or a ``parent_ca_cert`` PEM string.
+    """
+
+    def __new__(
+        cls,
+        cert,
+        key,
+        key_password,
+        *,
+        parent=None,
+        parent_ca_cert=None,
+        cert_chain=None,
+        serial=None,
+        _openssl_cli=None,
+        _chain_pem=None,
+        _verify_chain=None,
+    ):
+        """
+        Construct an intermediate CA from existing PEM data.
+
+        Either ``parent`` or ``parent_ca_cert`` must be provided (but not both)
+        when constructing from existing data (i.e. when ``_chain_pem`` is not given).
+
+        :param cert: intermediate CA certificate (PEM-encoded string)
+        :param key: intermediate CA private key (PEM-encoded string)
+        :param key_password: password to the private key
+        :param parent: parent CA object (RootCA or IntermediateCA) — chain context is derived automatically
+        :param parent_ca_cert: parent CA certificate (PEM-encoded string) — alternative to parent
+        :param cert_chain: full certificate chain (PEM-encoded string, optional — computed automatically)
+        :param serial: certificate serial number (hex string, optional)
+        """
+        if _chain_pem is not None:
+            # Internal construction path (from create_intermediate_ca).
+            chain_pem = _chain_pem
+            verify_chain = _verify_chain
+        elif parent is not None and parent_ca_cert is not None:
+            raise ValueError('Specify either parent or parent_ca_cert, not both')
+        elif parent is not None:
+            chain_pem = cert + parent._chain_pem
+            verify_chain = cert + parent._verify_chain
+        elif parent_ca_cert is not None:
+            chain_pem = cert
+            verify_chain = cert + parent_ca_cert
+        else:
+            raise ValueError('Either parent or parent_ca_cert must be provided')
+
+        if cert_chain is None:
+            cert_chain = chain_pem
+
+        openssl_cli = _openssl_cli or OpenSSLCLI()
+        obj = super().__new__(cls, cert=cert, key=key, key_password=key_password, cert_chain=cert_chain, serial=serial)
+        obj._openssl_cli = openssl_cli
+        obj._chain_pem = chain_pem
+        obj._verify_chain = verify_chain
+        return obj
+
+
+# Backward-compatible alias
+CA = RootCA

--- a/simple_ca/ca.py
+++ b/simple_ca/ca.py
@@ -1,17 +1,29 @@
-from .types import CKP, DEFAULT_VALIDITY_DAYS
+from .types import CertKeyPair, DEFAULT_VALIDITY_DAYS
 from .openssl_cli import OpenSSLCLI
 from .functions.init_ca import InitCA
 from .functions.create_intermediate_ca import CreateIntermediateCA
 from .functions.create_server_cert import CreateServerCert
 
 
-class _CABase(CKP):
+class _CABase:
     """
     Base class for Certificate Authorities.
 
     Provides shared functionality for creating intermediate CAs
     and server certificates. Not intended to be instantiated directly.
     """
+
+    def __init__(
+        self, *, cert, key, key_password, cert_chain=None, serial=None, openssl_cli=None, chain_pem='', verify_chain
+    ):
+        self.cert = cert
+        self.key = key
+        self.key_password = key_password
+        self.cert_chain = cert_chain
+        self.serial = serial
+        self._openssl_cli = openssl_cli or OpenSSLCLI()
+        self._chain_pem = chain_pem
+        self._verify_chain = verify_chain
 
     def create_intermediate_ca(self, org, cn='Intermediate CA', *, days=DEFAULT_VALIDITY_DAYS):
         """
@@ -52,7 +64,7 @@ class _CABase(CKP):
         :param dc: Domain Component (optional)
         :param san: list of Subject Alternative Names, e.g. ['DNS:localhost', '10.0.0.1'] (optional)
         :param days: certificate validity in days (default: DEFAULT_VALIDITY_DAYS)
-        :return: CKP namedtuple with cert, key, key_password, cert_chain and serial
+        :return: CertKeyPair with cert, key, key_password, cert_chain and serial
         """
         x = CreateServerCert(
             self._openssl_cli,
@@ -63,22 +75,19 @@ class _CABase(CKP):
         )
         x.run(cn=cn, org=org, dc=dc, san=san, days=days)
         cert_chain = x.cert + self._chain_pem
-        return CKP(cert=x.cert, key=x.key, key_password=x.key_password, cert_chain=cert_chain, serial=x.serial)
+        return CertKeyPair(cert=x.cert, key=x.key, key_password=x.key_password, cert_chain=cert_chain, serial=x.serial)
 
 
 class RootCA(_CABase):
     """
     Root Certificate Authority.
 
-    Inherits from CKP namedtuple, so it supports attribute access,
-    tuple unpacking and indexing.
-
     Create a new root CA using the class method :meth:`init_ca`,
     or construct directly from existing PEM data.
     """
 
-    def __new__(
-        cls,
+    def __init__(
+        self,
         cert,
         key,
         key_password,
@@ -98,13 +107,16 @@ class RootCA(_CABase):
         :param cert_chain: full certificate chain (PEM-encoded string, optional)
         :param serial: certificate serial number (hex string, optional)
         """
-        # Using __new__ instead of __init__ because namedtuple
-        # instances are created in __new__, not __init__.
-        obj = super().__new__(cls, cert=cert, key=key, key_password=key_password, cert_chain=cert_chain, serial=serial)
-        obj._openssl_cli = _openssl_cli or OpenSSLCLI()
-        obj._chain_pem = _chain_pem
-        obj._verify_chain = _verify_chain if _verify_chain is not None else cert
-        return obj
+        super().__init__(
+            cert=cert,
+            key=key,
+            key_password=key_password,
+            cert_chain=cert_chain,
+            serial=serial,
+            openssl_cli=_openssl_cli,
+            chain_pem=_chain_pem,
+            verify_chain=_verify_chain if _verify_chain is not None else cert,
+        )
 
     @classmethod
     def init_ca(cls, org, cn='CA', *, days=DEFAULT_VALIDITY_DAYS, _openssl_cli=None):
@@ -134,17 +146,14 @@ class IntermediateCA(_CABase):
     """
     Intermediate Certificate Authority.
 
-    Inherits from CKP namedtuple, so it supports attribute access,
-    tuple unpacking and indexing.
-
     Create a new intermediate CA using :meth:`RootCA.create_intermediate_ca`
     (or :meth:`IntermediateCA.create_intermediate_ca`),
     or construct directly from existing PEM data by providing
     either a ``parent`` CA object or a ``parent_ca_cert`` PEM string.
     """
 
-    def __new__(
-        cls,
+    def __init__(
+        self,
         cert,
         key,
         key_password,
@@ -189,12 +198,16 @@ class IntermediateCA(_CABase):
         if cert_chain is None:
             cert_chain = chain_pem
 
-        openssl_cli = _openssl_cli or OpenSSLCLI()
-        obj = super().__new__(cls, cert=cert, key=key, key_password=key_password, cert_chain=cert_chain, serial=serial)
-        obj._openssl_cli = openssl_cli
-        obj._chain_pem = chain_pem
-        obj._verify_chain = verify_chain
-        return obj
+        super().__init__(
+            cert=cert,
+            key=key,
+            key_password=key_password,
+            cert_chain=cert_chain,
+            serial=serial,
+            openssl_cli=_openssl_cli,
+            chain_pem=chain_pem,
+            verify_chain=verify_chain,
+        )
 
 
 # Backward-compatible alias

--- a/simple_ca/functions/create_intermediate_ca.py
+++ b/simple_ca/functions/create_intermediate_ca.py
@@ -1,4 +1,3 @@
-from ipaddress import ip_address
 from logging import getLogger
 from pathlib import Path
 from time import time_ns
@@ -9,8 +8,10 @@ from textwrap import dedent
 logger = getLogger(__name__)
 
 
-class CreateServerCert:
+class CreateIntermediateCA:
     """
+    Create an intermediate CA certificate signed by a parent CA.
+
     This class API may change (non-backward-compatible) between minor versions.
     """
 
@@ -22,73 +23,52 @@ class CreateServerCert:
         self.ca_key_password = ca_key_password
         self.ca_verify_chain = ca_verify_chain
 
-    def run(self, cn, org, dc, san=None):
+    def run(self, org, cn):
         with TemporaryDirectory(prefix='simple_ca.') as temp_dir:
             temp_dir = Path(temp_dir)
             self._conf_file = temp_dir / 'openssl.conf'
             self._ca_key_file = temp_dir / 'ca.key'
             self._ca_key_password_file = temp_dir / 'ca.key.password'
             self._ca_cert_file = temp_dir / 'ca.cert'
-            with self._ca_key_file.open('w') as f:
-                f.write(self.ca_key)
-            with self._ca_key_password_file.open('w') as f:
-                f.write(self.ca_key_password)
-            with self._ca_cert_file.open('w') as f:
-                f.write(self.ca_cert)
+            self._ca_key_file.write_text(self.ca_key)
+            self._ca_key_password_file.write_text(self.ca_key_password)
+            self._ca_cert_file.write_text(self.ca_cert)
             if self.ca_verify_chain:
                 self._ca_verify_file = temp_dir / 'ca_bundle.cert'
                 self._ca_verify_file.write_text(self.ca_verify_chain)
             else:
                 self._ca_verify_file = self._ca_cert_file
-            self._key_file = temp_dir / 'server.key'
-            self._key_password_file = temp_dir / 'server.key.password'
-            self._csr_file = temp_dir / 'server.csr'
-            self._cert_file = temp_dir / 'server.cert'
-            self._create_cfg(san=san)
+            self._key_file = temp_dir / 'intermediate.key'
+            self._key_password_file = temp_dir / 'intermediate.key.password'
+            self._csr_file = temp_dir / 'intermediate.csr'
+            self._cert_file = temp_dir / 'intermediate.cert'
+            self._create_cfg()
             self._create_key()
-            self._create_csr(cn=cn, org=org, dc=dc)
+            self._create_csr(org=org, cn=cn)
             self._create_cert()
             assert self.key_password
-            self.key = self._key_file.open().read()
-            self.cert = self._cert_file.open().read()
+            self.key = self._key_file.read_text()
+            self.cert = self._cert_file.read_text()
 
-    @staticmethod
-    def _san_entry(name):
-        if name.startswith(('DNS:', 'IP:')):
-            return name
-        try:
-            ip_address(name)
-            return 'IP:' + name
-        except ValueError:
-            return 'DNS:' + name
-
-    def _create_cfg(self, san=None):
+    def _create_cfg(self):
         assert not self._conf_file.is_file()
-        cfg = dedent("""
-            [req]
-            default_bits        = 4096
-            distinguished_name  = req_distinguished_name
-            string_mask         = utf8only
-            default_md          = sha256
-            [req_distinguished_name]
-            0.organizationName              = Organization Name
-            organizationalUnitName          = Organizational Unit Name
-            0.DC                            = Domain Component
-            commonName                      = Common Name
-            [v3_server_client]
-            basicConstraints        = CA:FALSE
-            nsCertType              = server, client
-            nsComment               = "OpenSSL Generated Server Certificate"
-            subjectKeyIdentifier    = hash
-            authorityKeyIdentifier  = keyid,issuer:always
-            keyUsage                = critical, nonRepudiation, digitalSignature, keyEncipherment
-            extendedKeyUsage        = serverAuth, clientAuth
-        """)
-        if san:
-            entries = ','.join(self._san_entry(s) for s in san)
-            cfg = cfg.rstrip() + '\nsubjectAltName          = ' + entries + '\n'
-        with self._conf_file.open('w') as f:
-            f.write(cfg)
+        self._conf_file.write_text(
+            dedent("""
+                [req]
+                default_bits        = 4096
+                distinguished_name  = req_distinguished_name
+                string_mask         = utf8only
+                default_md          = sha256
+                [req_distinguished_name]
+                0.organizationName     = Organization Name
+                commonName             = Common Name
+                [v3_intermediate_ca]
+                subjectKeyIdentifier   = hash
+                authorityKeyIdentifier = keyid:always,issuer
+                basicConstraints       = critical, CA:true, pathlen:0
+                keyUsage               = critical, digitalSignature, cRLSign, keyCertSign
+            """)
+        )
 
     def _create_key(self):
         assert not self._key_file.is_file()
@@ -96,20 +76,12 @@ class CreateServerCert:
         out = self.openssl_cli('rand', '-base64', 15)
         self.key_password = out.strip()
         assert len(self.key_password) == 15 / 3 * 4
-        with self._key_password_file.open('w') as f:
-            f.write(self.key_password)
+        self._key_password_file.write_text(self.key_password)
         self.openssl_cli(
             'genrsa', '-aes256', '-out', self._key_file, '-passout', 'file:' + str(self._key_password_file), 4096
         )
 
-    def _get_subj(self, cn, org, dc):
-        s = '/O=' + org
-        s += '/CN=' + cn
-        if dc:
-            s += '/DC=' + dc
-        return s
-
-    def _create_csr(self, cn, org, dc):
+    def _create_csr(self, org, cn):
         assert self._conf_file.is_file()
         assert self._key_file.is_file()
         assert self._key_password_file.is_file()
@@ -126,7 +98,7 @@ class CreateServerCert:
             '-out',
             self._csr_file,
             '-subj',
-            self._get_subj(cn=cn, org=org, dc=dc),
+            '/O={org}/CN={cn}'.format(org=org, cn=cn),
         )
         assert self._csr_file.is_file()
 
@@ -157,18 +129,18 @@ class CreateServerCert:
             '-out',
             self._cert_file,
             '-extensions',
-            'v3_server_client',
+            'v3_intermediate_ca',
         )
         assert self._cert_file.is_file()
-        # verify CA certificate
+        # verify intermediate CA certificate
         out = self.openssl_cli('x509', '-noout', '-text', '-in', self._cert_file)
         for line in out.splitlines():
-            self.logger.debug('Generated server cert: %s', line.rstrip())
-        assert 'CA:FALSE' in out
-        assert 'CA:TRUE' not in out
-        assert 'SSL Client' in out
-        assert 'SSL Server' in out
-        assert 'Certificate Sign' not in out
-        assert 'CRL Sign' not in out
+            self.logger.debug('Generated intermediate CA cert: %s', line.rstrip())
+        assert 'CA:TRUE' in out
+        assert 'CA:FALSE' not in out
+        assert 'Certificate Sign' in out
+        assert 'CRL Sign' in out
+        assert 'SSL Client' not in out
+        assert 'SSL Server' not in out
         out = self.openssl_cli('verify', '-CAfile', self._ca_verify_file, self._cert_file)
         assert 'OK' in out

--- a/simple_ca/functions/create_intermediate_ca.py
+++ b/simple_ca/functions/create_intermediate_ca.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 from textwrap import dedent
 
 from ..types import DEFAULT_VALIDITY_DAYS
+from .helpers import extract_serial
 
 
 logger = getLogger(__name__)
@@ -51,7 +52,7 @@ class CreateIntermediateCA:
             assert self.key_password
             self.key = self._key_file.read_text()
             self.cert = self._cert_file.read_text()
-            self._extract_serial()
+            self.serial = extract_serial(self.openssl_cli, self._cert_file)
 
     def _create_cfg(self):
         assert not self._conf_file.is_file()
@@ -104,10 +105,6 @@ class CreateIntermediateCA:
             '/O={org}/CN={cn}'.format(org=org, cn=cn),
         )
         assert self._csr_file.is_file()
-
-    def _extract_serial(self):
-        out = self.openssl_cli('x509', '-noout', '-serial', '-in', self._cert_file)
-        self.serial = out.strip().split('=', 1)[1]
 
     def _create_cert(self, days):
         assert self._conf_file.is_file()

--- a/simple_ca/functions/create_intermediate_ca.py
+++ b/simple_ca/functions/create_intermediate_ca.py
@@ -4,6 +4,8 @@ from time import time_ns
 from tempfile import TemporaryDirectory
 from textwrap import dedent
 
+from ..types import DEFAULT_VALIDITY_DAYS
+
 
 logger = getLogger(__name__)
 
@@ -23,7 +25,7 @@ class CreateIntermediateCA:
         self.ca_key_password = ca_key_password
         self.ca_verify_chain = ca_verify_chain
 
-    def run(self, org, cn):
+    def run(self, org, cn, days=DEFAULT_VALIDITY_DAYS):
         with TemporaryDirectory(prefix='simple_ca.') as temp_dir:
             temp_dir = Path(temp_dir)
             self._conf_file = temp_dir / 'openssl.conf'
@@ -45,10 +47,11 @@ class CreateIntermediateCA:
             self._create_cfg()
             self._create_key()
             self._create_csr(org=org, cn=cn)
-            self._create_cert()
+            self._create_cert(days=days)
             assert self.key_password
             self.key = self._key_file.read_text()
             self.cert = self._cert_file.read_text()
+            self._extract_serial()
 
     def _create_cfg(self):
         assert not self._conf_file.is_file()
@@ -102,7 +105,11 @@ class CreateIntermediateCA:
         )
         assert self._csr_file.is_file()
 
-    def _create_cert(self):
+    def _extract_serial(self):
+        out = self.openssl_cli('x509', '-noout', '-serial', '-in', self._cert_file)
+        self.serial = out.strip().split('=', 1)[1]
+
+    def _create_cert(self, days):
         assert self._conf_file.is_file()
         assert self._ca_cert_file.is_file()
         assert self._ca_key_file.is_file()
@@ -115,7 +122,7 @@ class CreateIntermediateCA:
             '-extfile',
             self._conf_file,
             '-days',
-            10000,
+            days,
             '-in',
             self._csr_file,
             '-CA',

--- a/simple_ca/functions/create_server_cert.py
+++ b/simple_ca/functions/create_server_cert.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 from textwrap import dedent
 
 from ..types import DEFAULT_VALIDITY_DAYS
+from .helpers import extract_serial
 
 
 logger = getLogger(__name__)
@@ -53,7 +54,7 @@ class CreateServerCert:
             assert self.key_password
             self.key = self._key_file.open().read()
             self.cert = self._cert_file.open().read()
-            self._extract_serial()
+            self.serial = extract_serial(self.openssl_cli, self._cert_file)
 
     @staticmethod
     def _san_entry(name):
@@ -132,10 +133,6 @@ class CreateServerCert:
             self._get_subj(cn=cn, org=org, dc=dc),
         )
         assert self._csr_file.is_file()
-
-    def _extract_serial(self):
-        out = self.openssl_cli('x509', '-noout', '-serial', '-in', self._cert_file)
-        self.serial = out.strip().split('=', 1)[1]
 
     def _create_cert(self, days):
         assert self._conf_file.is_file()

--- a/simple_ca/functions/create_server_cert.py
+++ b/simple_ca/functions/create_server_cert.py
@@ -5,6 +5,8 @@ from time import time_ns
 from tempfile import TemporaryDirectory
 from textwrap import dedent
 
+from ..types import DEFAULT_VALIDITY_DAYS
+
 
 logger = getLogger(__name__)
 
@@ -22,7 +24,7 @@ class CreateServerCert:
         self.ca_key_password = ca_key_password
         self.ca_verify_chain = ca_verify_chain
 
-    def run(self, cn, org, dc, san=None):
+    def run(self, cn, org, dc, san=None, days=DEFAULT_VALIDITY_DAYS):
         with TemporaryDirectory(prefix='simple_ca.') as temp_dir:
             temp_dir = Path(temp_dir)
             self._conf_file = temp_dir / 'openssl.conf'
@@ -47,10 +49,11 @@ class CreateServerCert:
             self._create_cfg(san=san)
             self._create_key()
             self._create_csr(cn=cn, org=org, dc=dc)
-            self._create_cert()
+            self._create_cert(days=days)
             assert self.key_password
             self.key = self._key_file.open().read()
             self.cert = self._cert_file.open().read()
+            self._extract_serial()
 
     @staticmethod
     def _san_entry(name):
@@ -130,7 +133,11 @@ class CreateServerCert:
         )
         assert self._csr_file.is_file()
 
-    def _create_cert(self):
+    def _extract_serial(self):
+        out = self.openssl_cli('x509', '-noout', '-serial', '-in', self._cert_file)
+        self.serial = out.strip().split('=', 1)[1]
+
+    def _create_cert(self, days):
         assert self._conf_file.is_file()
         assert self._ca_cert_file.is_file()
         assert self._ca_key_file.is_file()
@@ -143,7 +150,7 @@ class CreateServerCert:
             '-extfile',
             self._conf_file,
             '-days',
-            10000,
+            days,
             '-in',
             self._csr_file,
             '-CA',

--- a/simple_ca/functions/create_server_cert.py
+++ b/simple_ca/functions/create_server_cert.py
@@ -52,8 +52,8 @@ class CreateServerCert:
             self._create_csr(cn=cn, org=org, dc=dc)
             self._create_cert(days=days)
             assert self.key_password
-            self.key = self._key_file.open().read()
-            self.cert = self._cert_file.open().read()
+            self.key = self._key_file.read_text()
+            self.cert = self._cert_file.read_text()
             self.serial = extract_serial(self.openssl_cli, self._cert_file)
 
     @staticmethod

--- a/simple_ca/functions/helpers.py
+++ b/simple_ca/functions/helpers.py
@@ -1,0 +1,4 @@
+def extract_serial(openssl_cli, cert_file):
+    """Extract certificate serial number (hex string) from a cert file."""
+    out = openssl_cli('x509', '-noout', '-serial', '-in', cert_file)
+    return out.strip().split('=', 1)[1]

--- a/simple_ca/functions/init_ca.py
+++ b/simple_ca/functions/init_ca.py
@@ -30,8 +30,8 @@ class InitCA:
             self._create_key()
             self._create_cert(org=org, cn=cn, days=days)
             assert self.key_password
-            self.key = self._key_file.open().read()
-            self.cert = self._cert_file.open().read()
+            self.key = self._key_file.read_text()
+            self.cert = self._cert_file.read_text()
             self.serial = extract_serial(self.openssl_cli, self._cert_file)
 
     def _create_cfg(self):

--- a/simple_ca/functions/init_ca.py
+++ b/simple_ca/functions/init_ca.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from textwrap import dedent
 
+from ..types import DEFAULT_VALIDITY_DAYS
+
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +18,7 @@ class InitCA:
         self.logger = logger
         self.openssl_cli = openssl_cli
 
-    def run(self, org, cn):
+    def run(self, org, cn, days=DEFAULT_VALIDITY_DAYS):
         with TemporaryDirectory(prefix='simple_ca.') as temp_dir:
             temp_dir = Path(temp_dir)
             self._conf_file = temp_dir / 'openssl-ca.conf'
@@ -25,10 +27,11 @@ class InitCA:
             self._cert_file = temp_dir / 'ca.cert'
             self._create_cfg()
             self._create_key()
-            self._create_cert(org=org, cn=cn)
+            self._create_cert(org=org, cn=cn, days=days)
             assert self.key_password
             self.key = self._key_file.open().read()
             self.cert = self._cert_file.open().read()
+            self._extract_serial()
 
     def _create_cfg(self):
         assert not self._conf_file.is_file()
@@ -65,7 +68,11 @@ class InitCA:
             'genrsa', '-aes256', '-out', self._key_file, '-passout', 'file:' + str(self._key_password_file), 4096
         )
 
-    def _create_cert(self, org, cn):
+    def _extract_serial(self):
+        out = self.openssl_cli('x509', '-noout', '-serial', '-in', self._cert_file)
+        self.serial = out.strip().split('=', 1)[1]
+
+    def _create_cert(self, org, cn, days):
         assert self._conf_file.is_file()
         assert self._key_file.is_file()
         assert self._key_password_file.is_file()
@@ -79,7 +86,7 @@ class InitCA:
             '-new',
             '-x509',
             '-days',
-            10000,
+            days,
             '-key',
             self._key_file,
             '-passin',

--- a/simple_ca/functions/init_ca.py
+++ b/simple_ca/functions/init_ca.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 from textwrap import dedent
 
 from ..types import DEFAULT_VALIDITY_DAYS
+from .helpers import extract_serial
 
 
 logger = logging.getLogger(__name__)
@@ -31,7 +32,7 @@ class InitCA:
             assert self.key_password
             self.key = self._key_file.open().read()
             self.cert = self._cert_file.open().read()
-            self._extract_serial()
+            self.serial = extract_serial(self.openssl_cli, self._cert_file)
 
     def _create_cfg(self):
         assert not self._conf_file.is_file()
@@ -67,10 +68,6 @@ class InitCA:
         self.openssl_cli(
             'genrsa', '-aes256', '-out', self._key_file, '-passout', 'file:' + str(self._key_password_file), 4096
         )
-
-    def _extract_serial(self):
-        out = self.openssl_cli('x509', '-noout', '-serial', '-in', self._cert_file)
-        self.serial = out.strip().split('=', 1)[1]
 
     def _create_cert(self, org, cn, days):
         assert self._conf_file.is_file()

--- a/simple_ca/simple_ca.py
+++ b/simple_ca/simple_ca.py
@@ -1,7 +1,7 @@
 import logging
 
 from .ca import CA
-from .types import CKP, DEFAULT_VALIDITY_DAYS
+from .types import CertKeyPair, DEFAULT_VALIDITY_DAYS
 from .functions.init_ca import InitCA
 from .functions.create_server_cert import CreateServerCert
 from .openssl_cli import OpenSSLCLI
@@ -49,4 +49,4 @@ class SimpleCA:
         """
         x = CreateServerCert(self.openssl_cli, ca_cert=ca_cert, ca_key=ca_key, ca_key_password=ca_key_password)
         x.run(cn=cn, org=org, dc=dc, san=san, days=days)
-        return CKP(cert=x.cert, key=x.key, key_password=x.key_password, serial=x.serial)
+        return CertKeyPair(cert=x.cert, key=x.key, key_password=x.key_password, serial=x.serial)

--- a/simple_ca/simple_ca.py
+++ b/simple_ca/simple_ca.py
@@ -1,7 +1,7 @@
 import logging
 
 from .ca import CA
-from .types import CKP
+from .types import CKP, DEFAULT_VALIDITY_DAYS
 from .functions.init_ca import InitCA
 from .functions.create_server_cert import CreateServerCert
 from .openssl_cli import OpenSSLCLI
@@ -19,12 +19,23 @@ class SimpleCA:
         self.logger = logger
         self.openssl_cli = OpenSSLCLI()
 
-    def init_ca(self, org, cn='CA'):
+    def init_ca(self, org, cn='CA', *, days=DEFAULT_VALIDITY_DAYS):
         x = InitCA(self.openssl_cli)
-        x.run(org=org, cn=cn)
-        return CA(cert=x.cert, key=x.key, key_password=x.key_password, _openssl_cli=self.openssl_cli)
+        x.run(org=org, cn=cn, days=days)
+        return CA(cert=x.cert, key=x.key, key_password=x.key_password, serial=x.serial, _openssl_cli=self.openssl_cli)
 
-    def create_server_cert(self, ca_cert, ca_key, ca_key_password, cn, org, dc=None, san=None):
+    def create_server_cert(
+        self,
+        ca_cert,
+        ca_key,
+        ca_key_password,
+        cn,
+        org,
+        dc=None,
+        san=None,
+        *,
+        days=DEFAULT_VALIDITY_DAYS,
+    ):
         """
         Keyword arguments:
         - ca_cert: use value ca.cert from ca obtained from init_ca()
@@ -34,7 +45,8 @@ class SimpleCA:
         - org: Organization Name, most likely should be the same as CA org
         - dc: Domain Component
         - san: list of Subject Alternative Names (DNS names or IP addresses)
+        - days: certificate validity in days (keyword-only, default: DEFAULT_VALIDITY_DAYS)
         """
         x = CreateServerCert(self.openssl_cli, ca_cert=ca_cert, ca_key=ca_key, ca_key_password=ca_key_password)
-        x.run(cn=cn, org=org, dc=dc, san=san)
-        return CKP(cert=x.cert, key=x.key, key_password=x.key_password)
+        x.run(cn=cn, org=org, dc=dc, san=san, days=days)
+        return CKP(cert=x.cert, key=x.key, key_password=x.key_password, serial=x.serial)

--- a/simple_ca/types.py
+++ b/simple_ca/types.py
@@ -1,3 +1,5 @@
 from collections import namedtuple
 
-CKP = namedtuple('CKP', ('cert', 'key', 'key_password', 'cert_chain'), defaults=(None,))
+DEFAULT_VALIDITY_DAYS = 10000
+
+CKP = namedtuple('CKP', ('cert', 'key', 'key_password', 'cert_chain', 'serial'), defaults=(None, None))

--- a/simple_ca/types.py
+++ b/simple_ca/types.py
@@ -1,3 +1,3 @@
 from collections import namedtuple
 
-CKP = namedtuple('CKP', ('cert', 'key', 'key_password'))
+CKP = namedtuple('CKP', ('cert', 'key', 'key_password', 'cert_chain'), defaults=(None,))

--- a/simple_ca/types.py
+++ b/simple_ca/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 DEFAULT_VALIDITY_DAYS = 10000

--- a/simple_ca/types.py
+++ b/simple_ca/types.py
@@ -1,5 +1,14 @@
-from collections import namedtuple
+from dataclasses import dataclass
 
 DEFAULT_VALIDITY_DAYS = 10000
 
-CKP = namedtuple('CKP', ('cert', 'key', 'key_password', 'cert_chain', 'serial'), defaults=(None, None))
+
+@dataclass
+class CertKeyPair:
+    """Certificate, private key and related data."""
+
+    cert: str
+    key: str
+    key_password: str
+    cert_chain: str | None = None
+    serial: str | None = None

--- a/tests/test_ca.py
+++ b/tests/test_ca.py
@@ -63,10 +63,11 @@ def test_ca_is_instance_of_ckp():
 
 def test_ca_tuple_unpacking():
     ca = CA.init_ca(org='ACME')
-    cert, key, key_password = ca
+    cert, key, key_password, cert_chain = ca
     assert cert == ca.cert
     assert key == ca.key
     assert key_password == ca.key_password
+    assert cert_chain == ca.cert_chain
 
 
 def test_ca_indexing():
@@ -74,6 +75,7 @@ def test_ca_indexing():
     assert ca[0] == ca.cert
     assert ca[1] == ca.key
     assert ca[2] == ca.key_password
+    assert ca[3] == ca.cert_chain
 
 
 def test_create_server_cert():
@@ -174,3 +176,116 @@ def test_construct_ca_from_existing_pem():
     ca2 = CA(cert=ca1.cert, key=ca1.key, key_password=ca1.key_password)
     sc = ca2.create_server_cert(cn='localhost', org='ACME')
     _check_ckp(sc)
+
+
+def test_root_ca_cert_chain_is_none():
+    ca = CA.init_ca(org='ACME')
+    assert ca.cert_chain is None
+
+
+def test_server_cert_has_cert_chain():
+    ca = CA.init_ca(org='ACME')
+    sc = ca.create_server_cert(cn='localhost', org='ACME')
+    assert sc.cert_chain is not None
+    assert sc.cert_chain == sc.cert
+
+
+def test_create_intermediate_ca():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME', cn='Intermediate CA')
+    _check_ckp(inter)
+    assert isinstance(inter, CA)
+
+
+def test_intermediate_ca_is_ca_cert():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    out = _openssl_x509_text(inter.cert)
+    assert 'CA:TRUE' in out
+    assert 'Certificate Sign' in out
+    assert 'CRL Sign' in out
+
+
+def test_intermediate_ca_has_pathlen():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    out = _openssl_x509_text(inter.cert)
+    assert 'pathlen:0' in out
+
+
+def test_intermediate_ca_custom_cn():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME', cn='My Intermediate')
+    out = _openssl_x509_text(inter.cert)
+    assert 'My Intermediate' in out
+
+
+def test_intermediate_ca_verified_by_root(tmp_path):
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    (tmp_path / 'root.cert').write_text(root.cert)
+    (tmp_path / 'inter.cert').write_text(inter.cert)
+    result = subprocess.run(
+        ['openssl', 'verify', '-CAfile', str(tmp_path / 'root.cert'), str(tmp_path / 'inter.cert')],
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+
+def test_intermediate_ca_cert_chain():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    assert inter.cert_chain is not None
+    assert inter.cert in inter.cert_chain
+    assert root.cert not in inter.cert_chain
+
+
+def test_server_cert_from_intermediate():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    sc = inter.create_server_cert(cn='localhost', org='ACME')
+    _check_ckp(sc)
+    out = _openssl_x509_text(sc.cert)
+    assert 'CA:FALSE' in out
+
+
+def test_server_cert_from_intermediate_cert_chain():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    sc = inter.create_server_cert(cn='localhost', org='ACME')
+    # cert_chain should contain both server cert and intermediate cert
+    assert sc.cert in sc.cert_chain
+    assert inter.cert in sc.cert_chain
+    # but not the root cert
+    assert root.cert not in sc.cert_chain
+
+
+def test_server_cert_from_intermediate_verified(tmp_path):
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    sc = inter.create_server_cert(cn='localhost', org='ACME')
+    (tmp_path / 'root.cert').write_text(root.cert)
+    (tmp_path / 'inter.cert').write_text(inter.cert)
+    (tmp_path / 'server.cert').write_text(sc.cert)
+    result = subprocess.run(
+        [
+            'openssl',
+            'verify',
+            '-CAfile',
+            str(tmp_path / 'root.cert'),
+            '-untrusted',
+            str(tmp_path / 'inter.cert'),
+            str(tmp_path / 'server.cert'),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+
+def test_server_cert_from_intermediate_with_san():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    sc = inter.create_server_cert(cn='localhost', org='ACME', san=['localhost', '127.0.0.1'])
+    out = _openssl_x509_text(sc.cert)
+    assert 'DNS:localhost' in out
+    assert 'IP Address:127.0.0.1' in out

--- a/tests/test_ca.py
+++ b/tests/test_ca.py
@@ -207,107 +207,6 @@ def test_server_cert_has_cert_chain():
     assert sc.cert_chain == sc.cert
 
 
-def test_create_intermediate_ca():
-    root = CA.init_ca(org='ACME', cn='Root CA')
-    inter = root.create_intermediate_ca(org='ACME', cn='Intermediate CA')
-    _check_ckp(inter)
-    assert isinstance(inter, CA)
-
-
-def test_intermediate_ca_is_ca_cert():
-    root = CA.init_ca(org='ACME', cn='Root CA')
-    inter = root.create_intermediate_ca(org='ACME')
-    out = _openssl_x509_text(inter.cert)
-    assert 'CA:TRUE' in out
-    assert 'Certificate Sign' in out
-    assert 'CRL Sign' in out
-
-
-def test_intermediate_ca_has_pathlen():
-    root = CA.init_ca(org='ACME', cn='Root CA')
-    inter = root.create_intermediate_ca(org='ACME')
-    out = _openssl_x509_text(inter.cert)
-    assert 'pathlen:0' in out
-
-
-def test_intermediate_ca_custom_cn():
-    root = CA.init_ca(org='ACME', cn='Root CA')
-    inter = root.create_intermediate_ca(org='ACME', cn='My Intermediate')
-    out = _openssl_x509_text(inter.cert)
-    assert 'My Intermediate' in out
-
-
-def test_intermediate_ca_verified_by_root(tmp_path):
-    root = CA.init_ca(org='ACME', cn='Root CA')
-    inter = root.create_intermediate_ca(org='ACME')
-    (tmp_path / 'root.cert').write_text(root.cert)
-    (tmp_path / 'inter.cert').write_text(inter.cert)
-    result = subprocess.run(
-        ['openssl', 'verify', '-CAfile', str(tmp_path / 'root.cert'), str(tmp_path / 'inter.cert')],
-        capture_output=True,
-    )
-    assert result.returncode == 0
-
-
-def test_intermediate_ca_cert_chain():
-    root = CA.init_ca(org='ACME', cn='Root CA')
-    inter = root.create_intermediate_ca(org='ACME')
-    assert inter.cert_chain is not None
-    assert inter.cert in inter.cert_chain
-    assert root.cert not in inter.cert_chain
-
-
-def test_server_cert_from_intermediate():
-    root = CA.init_ca(org='ACME', cn='Root CA')
-    inter = root.create_intermediate_ca(org='ACME')
-    sc = inter.create_server_cert(cn='localhost', org='ACME')
-    _check_ckp(sc)
-    out = _openssl_x509_text(sc.cert)
-    assert 'CA:FALSE' in out
-
-
-def test_server_cert_from_intermediate_cert_chain():
-    root = CA.init_ca(org='ACME', cn='Root CA')
-    inter = root.create_intermediate_ca(org='ACME')
-    sc = inter.create_server_cert(cn='localhost', org='ACME')
-    # cert_chain should contain both server cert and intermediate cert
-    assert sc.cert in sc.cert_chain
-    assert inter.cert in sc.cert_chain
-    # but not the root cert
-    assert root.cert not in sc.cert_chain
-
-
-def test_server_cert_from_intermediate_verified(tmp_path):
-    root = CA.init_ca(org='ACME', cn='Root CA')
-    inter = root.create_intermediate_ca(org='ACME')
-    sc = inter.create_server_cert(cn='localhost', org='ACME')
-    (tmp_path / 'root.cert').write_text(root.cert)
-    (tmp_path / 'inter.cert').write_text(inter.cert)
-    (tmp_path / 'server.cert').write_text(sc.cert)
-    result = subprocess.run(
-        [
-            'openssl',
-            'verify',
-            '-CAfile',
-            str(tmp_path / 'root.cert'),
-            '-untrusted',
-            str(tmp_path / 'inter.cert'),
-            str(tmp_path / 'server.cert'),
-        ],
-        capture_output=True,
-    )
-    assert result.returncode == 0
-
-
-def test_server_cert_from_intermediate_with_san():
-    root = CA.init_ca(org='ACME', cn='Root CA')
-    inter = root.create_intermediate_ca(org='ACME')
-    sc = inter.create_server_cert(cn='localhost', org='ACME', san=['localhost', '127.0.0.1'])
-    out = _openssl_x509_text(sc.cert)
-    assert 'DNS:localhost' in out
-    assert 'IP Address:127.0.0.1' in out
-
-
 # --- days parameter tests ---
 
 
@@ -322,13 +221,6 @@ def test_create_server_cert_custom_validity():
     sc = ca.create_server_cert(cn='localhost', org='ACME', days=30)
     _check_ckp(sc)
     assert _get_cert_validity_days(sc.cert) == 30
-
-
-def test_create_intermediate_ca_custom_validity():
-    root = CA.init_ca(org='ACME', cn='Root CA')
-    inter = root.create_intermediate_ca(org='ACME', days=3650)
-    _check_ckp(inter)
-    assert _get_cert_validity_days(inter.cert) == 3650
 
 
 def test_default_validity_days_constant():
@@ -354,15 +246,6 @@ def test_server_cert_has_serial():
     assert isinstance(sc.serial, str)
     assert len(sc.serial) > 0
     int(sc.serial, 16)
-
-
-def test_intermediate_ca_has_serial():
-    root = CA.init_ca(org='ACME', cn='Root CA')
-    inter = root.create_intermediate_ca(org='ACME')
-    assert inter.serial is not None
-    assert isinstance(inter.serial, str)
-    assert len(inter.serial) > 0
-    int(inter.serial, 16)
 
 
 def test_serial_is_unique():

--- a/tests/test_ca.py
+++ b/tests/test_ca.py
@@ -4,8 +4,9 @@ Tests for the CA API.
 
 import re
 import subprocess
+from datetime import datetime
 
-from simple_ca import CA, CKP
+from simple_ca import CA, CKP, DEFAULT_VALIDITY_DAYS
 
 
 def _check_pem_cert(cert):
@@ -31,6 +32,20 @@ def _openssl_x509_text(cert_pem):
         ['openssl', 'x509', '-noout', '-text'],
         input=cert_pem.encode(),
     ).decode()
+
+
+def _get_cert_validity_days(cert_pem):
+    """Extract validity period in days from PEM certificate."""
+    out = subprocess.check_output(
+        ['openssl', 'x509', '-noout', '-startdate', '-enddate'],
+        input=cert_pem.encode(),
+    ).decode()
+    dates = {}
+    for line in out.strip().splitlines():
+        key, value = line.split('=', 1)
+        dates[key] = datetime.strptime(value, '%b %d %H:%M:%S %Y %Z')
+    delta = dates['notAfter'] - dates['notBefore']
+    return delta.days
 
 
 def test_init_ca():
@@ -63,11 +78,12 @@ def test_ca_is_instance_of_ckp():
 
 def test_ca_tuple_unpacking():
     ca = CA.init_ca(org='ACME')
-    cert, key, key_password, cert_chain = ca
+    cert, key, key_password, cert_chain, serial = ca
     assert cert == ca.cert
     assert key == ca.key
     assert key_password == ca.key_password
     assert cert_chain == ca.cert_chain
+    assert serial == ca.serial
 
 
 def test_ca_indexing():
@@ -76,6 +92,7 @@ def test_ca_indexing():
     assert ca[1] == ca.key
     assert ca[2] == ca.key_password
     assert ca[3] == ca.cert_chain
+    assert ca[4] == ca.serial
 
 
 def test_create_server_cert():
@@ -289,3 +306,67 @@ def test_server_cert_from_intermediate_with_san():
     out = _openssl_x509_text(sc.cert)
     assert 'DNS:localhost' in out
     assert 'IP Address:127.0.0.1' in out
+
+
+# --- days parameter tests ---
+
+
+def test_init_ca_custom_validity():
+    ca = CA.init_ca(org='ACME', days=365)
+    _check_ckp(ca)
+    assert _get_cert_validity_days(ca.cert) == 365
+
+
+def test_create_server_cert_custom_validity():
+    ca = CA.init_ca(org='ACME')
+    sc = ca.create_server_cert(cn='localhost', org='ACME', days=30)
+    _check_ckp(sc)
+    assert _get_cert_validity_days(sc.cert) == 30
+
+
+def test_create_intermediate_ca_custom_validity():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME', days=3650)
+    _check_ckp(inter)
+    assert _get_cert_validity_days(inter.cert) == 3650
+
+
+def test_default_validity_days_constant():
+    assert DEFAULT_VALIDITY_DAYS == 10000
+
+
+# --- serial field tests ---
+
+
+def test_init_ca_has_serial():
+    ca = CA.init_ca(org='ACME')
+    assert ca.serial is not None
+    assert isinstance(ca.serial, str)
+    assert len(ca.serial) > 0
+    # serial should be a hex string
+    int(ca.serial, 16)
+
+
+def test_server_cert_has_serial():
+    ca = CA.init_ca(org='ACME')
+    sc = ca.create_server_cert(cn='localhost', org='ACME')
+    assert sc.serial is not None
+    assert isinstance(sc.serial, str)
+    assert len(sc.serial) > 0
+    int(sc.serial, 16)
+
+
+def test_intermediate_ca_has_serial():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    assert inter.serial is not None
+    assert isinstance(inter.serial, str)
+    assert len(inter.serial) > 0
+    int(inter.serial, 16)
+
+
+def test_serial_is_unique():
+    ca = CA.init_ca(org='ACME')
+    sc1 = ca.create_server_cert(cn='server1', org='ACME')
+    sc2 = ca.create_server_cert(cn='server2', org='ACME')
+    assert sc1.serial != sc2.serial

--- a/tests/test_ca.py
+++ b/tests/test_ca.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 from datetime import datetime
 
-from simple_ca import CA, CKP, DEFAULT_VALIDITY_DAYS
+from simple_ca import CA, CertKeyPair, DEFAULT_VALIDITY_DAYS
 
 
 def _check_pem_cert(cert):
@@ -71,30 +71,6 @@ def test_init_ca_is_ca_cert():
     assert 'CA:TRUE' in out
 
 
-def test_ca_is_instance_of_ckp():
-    ca = CA.init_ca(org='ACME')
-    assert isinstance(ca, CKP)
-
-
-def test_ca_tuple_unpacking():
-    ca = CA.init_ca(org='ACME')
-    cert, key, key_password, cert_chain, serial = ca
-    assert cert == ca.cert
-    assert key == ca.key
-    assert key_password == ca.key_password
-    assert cert_chain == ca.cert_chain
-    assert serial == ca.serial
-
-
-def test_ca_indexing():
-    ca = CA.init_ca(org='ACME')
-    assert ca[0] == ca.cert
-    assert ca[1] == ca.key
-    assert ca[2] == ca.key_password
-    assert ca[3] == ca.cert_chain
-    assert ca[4] == ca.serial
-
-
 def test_create_server_cert():
     ca = CA.init_ca(org='ACME')
     sc = ca.create_server_cert(cn='localhost', org='ACME')
@@ -134,10 +110,10 @@ def test_server_cert_verified_by_ca(tmp_path):
     assert result.returncode == 0
 
 
-def test_server_cert_returns_ckp():
+def test_server_cert_returns_cert_key_pair():
     ca = CA.init_ca(org='ACME')
     sc = ca.create_server_cert(cn='localhost', org='ACME')
-    assert isinstance(sc, CKP)
+    assert isinstance(sc, CertKeyPair)
     assert not isinstance(sc, CA)
 
 

--- a/tests/test_ca_usage.py
+++ b/tests/test_ca_usage.py
@@ -51,11 +51,7 @@ async def _run_tls_http_server(server_ctx, host, port, ready_event):
                 break
         body = b'Hello, world!\n'
         response = (
-            b'HTTP/1.1 200 OK\r\n'
-            b'Content-Length: ' + str(len(body)).encode() + b'\r\n'
-            b'Connection: close\r\n'
-            b'\r\n'
-            + body
+            b'HTTP/1.1 200 OK\r\nContent-Length: ' + str(len(body)).encode() + b'\r\nConnection: close\r\n\r\n' + body
         )
         writer.write(response)
         await writer.drain()
@@ -279,8 +275,12 @@ async def test_https_curl(tmp_path):
         port = ready_event.port
 
         proc = await create_subprocess_exec(
-            'curl', '--cacert', str(ca_cert_path), f'https://localhost:{port}/',
-            stdout=PIPE, stderr=PIPE,
+            'curl',
+            '--cacert',
+            str(ca_cert_path),
+            f'https://localhost:{port}/',
+            stdout=PIPE,
+            stderr=PIPE,
         )
         stdout, stderr = await proc.communicate()
         assert proc.returncode == 0, f'curl failed: {stderr.decode()}'
@@ -319,8 +319,12 @@ async def test_https_curl_intermediate_ca(tmp_path):
         port = ready_event.port
 
         proc = await create_subprocess_exec(
-            'curl', '--cacert', str(root_cert_path), f'https://localhost:{port}/',
-            stdout=PIPE, stderr=PIPE,
+            'curl',
+            '--cacert',
+            str(root_cert_path),
+            f'https://localhost:{port}/',
+            stdout=PIPE,
+            stderr=PIPE,
         )
         stdout, stderr = await proc.communicate()
         assert proc.returncode == 0, f'curl failed: {stderr.decode()}'

--- a/tests/test_ca_usage.py
+++ b/tests/test_ca_usage.py
@@ -115,6 +115,87 @@ async def test_tls_san_ip(tmp_path):
 
 
 @mark.asyncio
+async def test_tls_intermediate_ca(tmp_path):
+    """TLS with intermediate CA — server must send fullchain (cert_chain)."""
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME', cn='Intermediate CA')
+    sc = inter.create_server_cert(cn='localhost', org='ACME', san=['localhost'])
+
+    # Client trusts only root CA
+    root_cert_path = tmp_path / 'root.pem'
+    root_cert_path.write_text(root.cert)
+
+    # Server uses fullchain (server cert + intermediate cert)
+    fullchain_path = tmp_path / 'fullchain.pem'
+    fullchain_path.write_text(sc.cert_chain)
+    server_key_path = tmp_path / 'server.key'
+    server_key_path.write_text(sc.key)
+
+    server_ctx = SSLContext(PROTOCOL_TLS_SERVER)
+    server_ctx.load_cert_chain(fullchain_path, server_key_path, password=sc.key_password)
+
+    client_ctx = create_default_context(cafile=str(root_cert_path))
+
+    ready_event = Event()
+    server_task = create_task(_run_tls_echo_server(server_ctx, '127.0.0.1', 0, ready_event))
+
+    try:
+        await ready_event.wait()
+        port = ready_event.port
+
+        reader, writer = await open_connection('127.0.0.1', port, ssl=client_ctx, server_hostname='localhost')
+        writer.write(b'hello intermediate TLS')
+        await writer.drain()
+
+        data = await reader.read(4096)
+        assert data == b'hello intermediate TLS'
+
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server_task.cancel()
+        try:
+            await server_task
+        except CancelledError:
+            pass
+
+
+@mark.asyncio
+async def test_tls_intermediate_ca_without_fullchain_rejected(tmp_path):
+    """Without fullchain, client cannot verify the server cert signed by intermediate CA."""
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME', cn='Intermediate CA')
+    sc = inter.create_server_cert(cn='localhost', org='ACME', san=['localhost'])
+
+    root_cert_path = tmp_path / 'root.pem'
+    root_cert_path.write_text(root.cert)
+
+    # Server sends only server cert, NOT fullchain
+    server_cert_path, server_key_path = _write_ckp(tmp_path, 'server', sc)
+
+    server_ctx = SSLContext(PROTOCOL_TLS_SERVER)
+    server_ctx.load_cert_chain(server_cert_path, server_key_path, password=sc.key_password)
+
+    client_ctx = create_default_context(cafile=str(root_cert_path))
+
+    ready_event = Event()
+    server_task = create_task(_run_tls_echo_server(server_ctx, '127.0.0.1', 0, ready_event))
+
+    try:
+        await ready_event.wait()
+        port = ready_event.port
+
+        with raises(SSLCertVerificationError):
+            reader, writer = await open_connection('127.0.0.1', port, ssl=client_ctx, server_hostname='localhost')
+    finally:
+        server_task.cancel()
+        try:
+            await server_task
+        except CancelledError:
+            pass
+
+
+@mark.asyncio
 async def test_tls_wrong_ca_rejected(tmp_path):
     ca1 = CA.init_ca(org='ACME-1')
     ca2 = CA.init_ca(org='ACME-2')

--- a/tests/test_ca_usage.py
+++ b/tests/test_ca_usage.py
@@ -291,3 +291,43 @@ async def test_https_curl(tmp_path):
             await server_task
         except CancelledError:
             pass
+
+
+@mark.asyncio
+async def test_https_curl_intermediate_ca(tmp_path):
+    """HTTPS + curl with intermediate CA — server sends fullchain, curl trusts only root."""
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME', cn='Intermediate CA')
+    sc = inter.create_server_cert(cn='localhost', org='ACME', san=['localhost'])
+
+    root_cert_path = tmp_path / 'root.pem'
+    root_cert_path.write_text(root.cert)
+
+    fullchain_path = tmp_path / 'fullchain.pem'
+    fullchain_path.write_text(sc.cert_chain)
+    server_key_path = tmp_path / 'server.key'
+    server_key_path.write_text(sc.key)
+
+    server_ctx = SSLContext(PROTOCOL_TLS_SERVER)
+    server_ctx.load_cert_chain(fullchain_path, server_key_path, password=sc.key_password)
+
+    ready_event = Event()
+    server_task = create_task(_run_tls_http_server(server_ctx, '127.0.0.1', 0, ready_event))
+
+    try:
+        await ready_event.wait()
+        port = ready_event.port
+
+        proc = await create_subprocess_exec(
+            'curl', '--cacert', str(root_cert_path), f'https://localhost:{port}/',
+            stdout=PIPE, stderr=PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        assert proc.returncode == 0, f'curl failed: {stderr.decode()}'
+        assert stdout == b'Hello, world!\n'
+    finally:
+        server_task.cancel()
+        try:
+            await server_task
+        except CancelledError:
+            pass

--- a/tests/test_ca_usage.py
+++ b/tests/test_ca_usage.py
@@ -4,7 +4,8 @@ TLS integration tests — verify that generated certificates work in real TLS co
 Uses asyncio TCP server/client with ssl.SSLContext to test end-to-end TLS.
 """
 
-from asyncio import CancelledError, Event, create_task, open_connection, start_server
+from asyncio import CancelledError, Event, create_subprocess_exec, create_task, open_connection, start_server
+from asyncio.subprocess import PIPE
 from ssl import SSLCertVerificationError, SSLContext, PROTOCOL_TLS_SERVER, create_default_context
 
 from pytest import mark, raises
@@ -27,6 +28,36 @@ async def _run_tls_echo_server(server_ctx, host, port, ready_event):
     async def handle_client(reader, writer):
         data = await reader.read(4096)
         writer.write(data)
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    server = await start_server(handle_client, host, port, ssl=server_ctx)
+    actual_port = server.sockets[0].getsockname()[1]
+    ready_event.port = actual_port
+    ready_event.set()
+    async with server:
+        await server.serve_forever()
+
+
+async def _run_tls_http_server(server_ctx, host, port, ready_event):
+    """Minimal HTTPS server — responds with 'Hello, world!\\n' to any request."""
+
+    async def handle_client(reader, writer):
+        # Read HTTP request headers until blank line
+        while True:
+            line = await reader.readline()
+            if line in (b'\r\n', b'\n', b''):
+                break
+        body = b'Hello, world!\n'
+        response = (
+            b'HTTP/1.1 200 OK\r\n'
+            b'Content-Length: ' + str(len(body)).encode() + b'\r\n'
+            b'Connection: close\r\n'
+            b'\r\n'
+            + body
+        )
+        writer.write(response)
         await writer.drain()
         writer.close()
         await writer.wait_closed()
@@ -219,6 +250,41 @@ async def test_tls_wrong_ca_rejected(tmp_path):
 
         with raises(SSLCertVerificationError):
             reader, writer = await open_connection('127.0.0.1', port, ssl=client_ctx, server_hostname='localhost')
+    finally:
+        server_task.cancel()
+        try:
+            await server_task
+        except CancelledError:
+            pass
+
+
+@mark.asyncio
+async def test_https_curl(tmp_path):
+    """HTTPS test using curl as the client — verifies certificates work with real tools."""
+    ca = CA.init_ca(org='ACME')
+    sc = ca.create_server_cert(cn='localhost', org='ACME', san=['localhost'])
+
+    ca_cert_path = tmp_path / 'ca.pem'
+    ca_cert_path.write_text(ca.cert)
+    server_cert_path, server_key_path = _write_ckp(tmp_path, 'server', sc)
+
+    server_ctx = SSLContext(PROTOCOL_TLS_SERVER)
+    server_ctx.load_cert_chain(server_cert_path, server_key_path, password=sc.key_password)
+
+    ready_event = Event()
+    server_task = create_task(_run_tls_http_server(server_ctx, '127.0.0.1', 0, ready_event))
+
+    try:
+        await ready_event.wait()
+        port = ready_event.port
+
+        proc = await create_subprocess_exec(
+            'curl', '--cacert', str(ca_cert_path), f'https://localhost:{port}/',
+            stdout=PIPE, stderr=PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        assert proc.returncode == 0, f'curl failed: {stderr.decode()}'
+        assert stdout == b'Hello, world!\n'
     finally:
         server_task.cancel()
         try:

--- a/tests/test_intermediate_ca.py
+++ b/tests/test_intermediate_ca.py
@@ -1,0 +1,281 @@
+"""
+Tests for the IntermediateCA API — creating intermediate CAs,
+reconstructing from existing PEM data, and signing server certs.
+"""
+
+import re
+import subprocess
+from datetime import datetime
+
+from pytest import raises
+
+from simple_ca import CA, IntermediateCA, RootCA
+
+
+def _check_pem_cert(cert):
+    assert isinstance(cert, str)
+    assert '-----BEGIN CERTIFICATE-----' in cert
+    assert '-----END CERTIFICATE-----' in cert
+
+
+def _check_pem_key(key):
+    assert isinstance(key, str)
+    assert re.match(r'-----BEGIN (ENCRYPTED|RSA) PRIVATE KEY-----', key)
+
+
+def _check_ckp(ckp):
+    _check_pem_cert(ckp.cert)
+    _check_pem_key(ckp.key)
+    assert isinstance(ckp.key_password, str)
+    assert len(ckp.key_password) > 10
+
+
+def _openssl_x509_text(cert_pem):
+    return subprocess.check_output(
+        ['openssl', 'x509', '-noout', '-text'],
+        input=cert_pem.encode(),
+    ).decode()
+
+
+def _get_cert_validity_days(cert_pem):
+    """Extract validity period in days from PEM certificate."""
+    out = subprocess.check_output(
+        ['openssl', 'x509', '-noout', '-startdate', '-enddate'],
+        input=cert_pem.encode(),
+    ).decode()
+    dates = {}
+    for line in out.strip().splitlines():
+        key, value = line.split('=', 1)
+        dates[key] = datetime.strptime(value, '%b %d %H:%M:%S %Y %Z')
+    delta = dates['notAfter'] - dates['notBefore']
+    return delta.days
+
+
+# --- RootCA / CA alias ---
+
+
+def test_root_ca_alias():
+    assert CA is RootCA
+
+
+def test_root_ca_init_ca():
+    ca = RootCA.init_ca(org='ACME')
+    _check_ckp(ca)
+    assert isinstance(ca, RootCA)
+
+
+# --- Creating intermediate CA ---
+
+
+def test_create_intermediate_ca():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME', cn='Intermediate CA')
+    _check_ckp(inter)
+    assert isinstance(inter, IntermediateCA)
+
+
+def test_intermediate_ca_is_ca_cert():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    out = _openssl_x509_text(inter.cert)
+    assert 'CA:TRUE' in out
+    assert 'Certificate Sign' in out
+    assert 'CRL Sign' in out
+
+
+def test_intermediate_ca_has_pathlen():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    out = _openssl_x509_text(inter.cert)
+    assert 'pathlen:0' in out
+
+
+def test_intermediate_ca_custom_cn():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME', cn='My Intermediate')
+    out = _openssl_x509_text(inter.cert)
+    assert 'My Intermediate' in out
+
+
+def test_intermediate_ca_verified_by_root(tmp_path):
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    (tmp_path / 'root.cert').write_text(root.cert)
+    (tmp_path / 'inter.cert').write_text(inter.cert)
+    result = subprocess.run(
+        ['openssl', 'verify', '-CAfile', str(tmp_path / 'root.cert'), str(tmp_path / 'inter.cert')],
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+
+def test_intermediate_ca_cert_chain():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    assert inter.cert_chain is not None
+    assert inter.cert in inter.cert_chain
+    assert root.cert not in inter.cert_chain
+
+
+def test_intermediate_ca_custom_validity():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME', days=3650)
+    _check_ckp(inter)
+    assert _get_cert_validity_days(inter.cert) == 3650
+
+
+def test_intermediate_ca_has_serial():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    assert inter.serial is not None
+    assert isinstance(inter.serial, str)
+    assert len(inter.serial) > 0
+    int(inter.serial, 16)
+
+
+# --- Server certs from intermediate CA ---
+
+
+def test_server_cert_from_intermediate():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    sc = inter.create_server_cert(cn='localhost', org='ACME')
+    _check_ckp(sc)
+    out = _openssl_x509_text(sc.cert)
+    assert 'CA:FALSE' in out
+
+
+def test_server_cert_from_intermediate_cert_chain():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    sc = inter.create_server_cert(cn='localhost', org='ACME')
+    # cert_chain should contain both server cert and intermediate cert
+    assert sc.cert in sc.cert_chain
+    assert inter.cert in sc.cert_chain
+    # but not the root cert
+    assert root.cert not in sc.cert_chain
+
+
+def test_server_cert_from_intermediate_verified(tmp_path):
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    sc = inter.create_server_cert(cn='localhost', org='ACME')
+    (tmp_path / 'root.cert').write_text(root.cert)
+    (tmp_path / 'inter.cert').write_text(inter.cert)
+    (tmp_path / 'server.cert').write_text(sc.cert)
+    result = subprocess.run(
+        [
+            'openssl',
+            'verify',
+            '-CAfile',
+            str(tmp_path / 'root.cert'),
+            '-untrusted',
+            str(tmp_path / 'inter.cert'),
+            str(tmp_path / 'server.cert'),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+
+def test_server_cert_from_intermediate_with_san():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter = root.create_intermediate_ca(org='ACME')
+    sc = inter.create_server_cert(cn='localhost', org='ACME', san=['localhost', '127.0.0.1'])
+    out = _openssl_x509_text(sc.cert)
+    assert 'DNS:localhost' in out
+    assert 'IP Address:127.0.0.1' in out
+
+
+# --- Reconstructing IntermediateCA from existing PEM data ---
+
+
+def test_construct_intermediate_ca_from_existing_with_parent():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter_orig = root.create_intermediate_ca(org='ACME', cn='Intermediate CA')
+    # Reconstruct from existing PEM data using parent CA object
+    inter = IntermediateCA(
+        cert=inter_orig.cert,
+        key=inter_orig.key,
+        key_password=inter_orig.key_password,
+        parent=root,
+    )
+    assert isinstance(inter, IntermediateCA)
+    _check_ckp(inter)
+    # Should be able to create server certs
+    sc = inter.create_server_cert(cn='localhost', org='ACME', san=['localhost'])
+    _check_ckp(sc)
+    # cert_chain should contain both server cert and intermediate cert
+    assert sc.cert in sc.cert_chain
+    assert inter.cert in sc.cert_chain
+
+
+def test_construct_intermediate_ca_from_existing_with_parent_ca_cert():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter_orig = root.create_intermediate_ca(org='ACME', cn='Intermediate CA')
+    # Reconstruct from existing PEM data using raw parent cert string
+    inter = IntermediateCA(
+        cert=inter_orig.cert,
+        key=inter_orig.key,
+        key_password=inter_orig.key_password,
+        parent_ca_cert=root.cert,
+    )
+    assert isinstance(inter, IntermediateCA)
+    _check_ckp(inter)
+    sc = inter.create_server_cert(cn='localhost', org='ACME', san=['localhost'])
+    _check_ckp(sc)
+    assert sc.cert in sc.cert_chain
+    assert inter.cert in sc.cert_chain
+
+
+def test_intermediate_ca_from_existing_server_cert_verified(tmp_path):
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter_orig = root.create_intermediate_ca(org='ACME')
+    # Reconstruct intermediate CA from PEM data
+    inter = IntermediateCA(
+        cert=inter_orig.cert,
+        key=inter_orig.key,
+        key_password=inter_orig.key_password,
+        parent=root,
+    )
+    sc = inter.create_server_cert(cn='localhost', org='ACME')
+    (tmp_path / 'root.cert').write_text(root.cert)
+    (tmp_path / 'inter.cert').write_text(inter.cert)
+    (tmp_path / 'server.cert').write_text(sc.cert)
+    result = subprocess.run(
+        [
+            'openssl',
+            'verify',
+            '-CAfile',
+            str(tmp_path / 'root.cert'),
+            '-untrusted',
+            str(tmp_path / 'inter.cert'),
+            str(tmp_path / 'server.cert'),
+        ],
+        capture_output=True,
+    )
+    assert result.returncode == 0
+
+
+def test_intermediate_ca_requires_parent():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter_orig = root.create_intermediate_ca(org='ACME')
+    with raises(ValueError, match='Either parent or parent_ca_cert must be provided'):
+        IntermediateCA(
+            cert=inter_orig.cert,
+            key=inter_orig.key,
+            key_password=inter_orig.key_password,
+        )
+
+
+def test_intermediate_ca_rejects_both_parent_and_parent_ca_cert():
+    root = CA.init_ca(org='ACME', cn='Root CA')
+    inter_orig = root.create_intermediate_ca(org='ACME')
+    with raises(ValueError, match='Specify either parent or parent_ca_cert, not both'):
+        IntermediateCA(
+            cert=inter_orig.cert,
+            key=inter_orig.key,
+            key_password=inter_orig.key_password,
+            parent=root,
+            parent_ca_cert=root.cert,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -164,6 +173,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -199,6 +222,7 @@ dev = [
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -208,6 +232,7 @@ dev = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff" },
 ]
 


### PR DESCRIPTION
Introduce CA.create_intermediate_ca() for creating intermediate CAs signed by a parent CA, with proper chain building for TLS. Add cert_chain field to CKP namedtuple so server certs include the full chain needed by TLS servers. Update docs and add comprehensive tests including TLS integration.